### PR TITLE
Hotfix/failing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project tries to follow [Semantic Versioning](http://semver.org/).
 
 ## [0.9.8] - 2021-02-21
 
+### Changed
+
 - Docker: upgrade alpine (1.17.8 -> 1.19.6)
 
 ## [0.9.7] - 2020-02-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project tries to follow [Semantic Versioning](http://semver.org/).
 
+## [0.9.9] - 2021-02-21
+
+### Fixed
+
+- Tests: failing tests due to new newlines
+
 ## [0.9.8] - 2021-02-21
 
 - Docker: upgrade alpine (1.17.8 -> 1.19.6)

--- a/test/_test_nginx_cfg_main.sh
+++ b/test/_test_nginx_cfg_main.sh
@@ -6,6 +6,8 @@
 testHttpSectionEmpty(){
 	expected="http {
 
+
+
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
@@ -67,6 +69,8 @@ events {
 }
 
 http {
+
+
 
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;


### PR DESCRIPTION
This PR fixes the test cases. New newlines are generated somewhere. As more empty lines are irrelevant to nginx, the test cases were changed without actually trying to remove the newlines from the generated configuration.